### PR TITLE
Use `argv[0]` instead of macro `PROGEXECNAME`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,10 @@
 #include <stdio.h>
-#define PROGEXECNAME "./c-alculator"
 #define VER "0.0.1"
 #define NAME "c-alculator"
 
-void help() {
+void help(char *argv0) {
 	printf("\e[1m%s version %s built on %s.\e[0m\n", NAME, VER, __TIMESTAMP__);
-	printf("\e[Usage:\e[0m %s [num1] [operation] [num2]\n", PROGEXECNAME);
+	printf("\e[Usage:\e[0m %s [num1] [operation] [num2]\n", argv0);
 	printf("\e[Operations:\e[0m +, -, x, /.  x=*\n");
 }
 
@@ -14,7 +13,7 @@ int main (int argc, char **argv)
 {
     if(argc>1) {
 		if(!strcasecmp(argv[1], "--help")||!strcasecmp(argv[1], "-h")) {
-			help();
+			help(argv[0]);
 			return 0;
 		}
 	}


### PR DESCRIPTION
the first argument (`argv[0]`) always exists and is the name of the binary/path to the binary that was run.
for example if I run a program like this: `./prog`, `argv[0]` will be `./prog`.
and if it is run like this:`/path/to/prog`, `argv[0]` will be `/path/to/prog`.
